### PR TITLE
Update CSV_test_SOMANET_v42.c

### DIFF
--- a/EtherCAT/SOEM/CSV_test_SOMANET_v42.c
+++ b/EtherCAT/SOEM/CSV_test_SOMANET_v42.c
@@ -26,7 +26,8 @@ boolean inOP;
 uint8 currentgroup = 0;
 
 /* define pointer structure */
-typedef struct PACKED
+#pragma pack(1)
+typedef struct
 {
   int16 Statusword;
   int8  OpModeDisplay;
@@ -51,7 +52,7 @@ typedef struct PACKED
   int16 TorqueDemand;
 } in_somanet_42t;
 
-typedef struct PACKED
+typedef struct
 {
   int16 Controlword;
   int8  OpMode;
@@ -67,7 +68,7 @@ typedef struct PACKED
   int32 UserMOSI;
   int32 VelocityOffset;
 } out_somanet_42t;
-
+#pragma pack()
 
 void simpletest(char *ifname)
 {


### PR DESCRIPTION
I don't have push access to this repo and have to open a pull request.

In the original code, the PACKED in the struct definition is merely an identifier instead of a keyword. The defined structs are not actually packed and will cause misalignment issues. `#pragma pack` should be used here for the intended function.
